### PR TITLE
fix: Update job module from using `user.id` in place of `employer.id`

### DIFF
--- a/backend/src/controllers/job.controller.ts
+++ b/backend/src/controllers/job.controller.ts
@@ -20,7 +20,11 @@ export class JobController extends BaseController {
 		const output = JobValidator.safeParse(req.body);
 		const data = (output as any).data;
 
-		const job = await JobService.create({ ...data, employer: req.user?.id });
+		if (!req.user) {
+			return;
+		}
+
+		const job = await JobService.create({ ...data }, req.user.id);
 
 		return res.status(StatusCodes.CREATED).json({
 			data: job,
@@ -106,5 +110,10 @@ export class JobController extends BaseController {
 		} else {
 			return res.sendStatus(StatusCodes.NO_CONTENT);
 		}
+	}
+
+	@Post("/:id/apply", isLoggedIn)
+	async applyForJob(req: AuthRequest, res: Response) {
+		return res.sendStatus(StatusCodes.NO_CONTENT);
 	}
 }

--- a/backend/src/services/job.ts
+++ b/backend/src/services/job.ts
@@ -1,4 +1,5 @@
 import { BadRequestError, CustomAPIError, NotFoundError } from "@/errors";
+import Employer from "@/models/employer";
 import JobListing from "@/models/job.listing";
 import { JobUpdateValidator, JobValidator } from "@/validators/job";
 import { StatusCodes } from "http-status-codes";
@@ -6,8 +7,18 @@ import mongoose from "mongoose";
 import { z } from "zod";
 
 class JobService {
-	static async create(data: z.infer<typeof JobValidator>) {
-		const job = await JobListing.create({ ...data });
+	static async create(data: z.infer<typeof JobValidator>, id: string) {
+		const employer = await Employer.findOne({
+			user: id,
+		});
+
+		if (!employer) {
+			throw new NotFoundError(
+				"The user does not have a role model yet. Please create a role for the user.",
+			);
+		}
+
+		const job = await JobListing.create({ ...data, employer: employer.id });
 
 		if (!job) {
 			throw new CustomAPIError("Couldn't create a job", 500);


### PR DESCRIPTION
In the `JobController`:
- Added a new `applyForJob` method to handle job applications.

In the `JobService`:
- Check if the user has an associated employer before creating a job listing
- Throw a `NotFoundError` if no associated employer is found.
- Use the employer's ID when creating a job listing.